### PR TITLE
Correction to Redis store details

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ If choosing the Redis store, you also need to provide additional configurations 
 ```javascript
 const session = new Session({
     framework: "oak",
-    store: "memory",
+    store: "redis",
     hostname: "127.0.0.1";
     port: 6379,
 });


### PR DESCRIPTION
From the top of the file, to use Redis database, the store configuration option should be "redis" not "memory". Since the example is talking explicitly about Redis store configuration, the value should be "redis"